### PR TITLE
convert docs for Projects and Response fields

### DIFF
--- a/source/includes/project-forms.md
+++ b/source/includes/project-forms.md
@@ -1,0 +1,141 @@
+# Project forms
+
+## List a project's response fields
+
+```shell
+[
+  {
+    "id": 235,
+    "form_id": 42,
+    "label": "Your Approach",
+    "field_options": {
+      "size": "medium",
+      "description": "How would you complete this project?"
+    },
+    "sort_order": 0,
+    "required": true,
+    "blind": false,
+    "admin_only": false,
+    "created_at": "2014-07-29T23:42:52.319Z",
+    "updated_at": "2014-07-29T23:42:52.319Z",
+    "field_type": "paragraph",
+    "cid": null
+  },
+  {
+    "id": 236,
+    "form_id": 42,
+    "label": "Previous Work",
+    "field_options": {
+      "size": "medium",
+      "description": "What qualifies you to work on this project?"
+    },
+    "sort_order": 1,
+    "required": true,
+    "blind": false,
+    "admin_only": false,
+    "created_at": "2014-07-29T23:42:52.327Z",
+    "updated_at": "2014-07-29T23:42:52.327Z",
+    "field_type": "paragraph",
+    "cid": null
+  },
+  ...
+]
+```
+
+### HTTP Request
+
+`GET /projects/:project_id/response_fields`
+
+## Add a response field
+
+Add a response field to a project's form.
+
+```shell
+curl /projects/:project_id/response_fields/:response_field_id \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  -d '
+{
+  "field_type": "text",
+  "label": "Your Approach"
+}
+'
+```
+
+### HTTP Request
+
+`POST /projects/:project_id/response_fields`
+
+## Update a response field
+
+```shell
+curl /projects/:project_id/response_fields/:response_field_id \
+  -H 'Content-Type: application/json' \
+  -X PUT \
+  -d '
+{
+  "field_type": "text",
+  "label": "Your Approach"
+}
+'
+```
+
+### HTTP Request
+
+`PUT /projects/:project_id/response_fields/:response_field_id`
+
+## Delete a response field
+
+Deletes a response field. Note that you will lose any responses to this.
+
+```shell
+curl /projects/:project_id/response_fields/:response_field_id \
+  -H 'Content-Type: application/json' \
+  -X DELETE
+```
+
+### HTTP Request
+
+`DELETE /projects/:project_id/response_fields/:response_field_id`
+
+## Batch-update a project's form
+
+Batch-updates the form for a project. Any response fields that don't exist will be added, and any existing fields that aren't present in the request body will be destroyed.
+
+```shell
+curl /projects/:project_id/response_fields/:response_field_id/batch \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  -d '
+{
+  "response_fields": [
+    {
+      "id": 235,
+      "label": "Your Approach",
+      "field_options": {
+        "size": "medium",
+        "description": "How would you complete this project?"
+      },
+      "required": true,
+      "blind": false,
+      "admin_only": false,
+      "field_type": "paragraph",
+    },
+    {
+      "label": "Previous Work",
+      "field_options": {
+        "size": "medium",
+        "description": "What qualifies you to work on this project?"
+      },
+      "required": true,
+      "field_type": "paragraph",
+    }
+  ]
+}
+'
+```
+
+### HTTP Request
+
+`POST /projects/:project_id/response_fields/:response_field_id/batch`
+

--- a/source/includes/projects.md
+++ b/source/includes/projects.md
@@ -1,0 +1,120 @@
+# Projects
+
+## List a site's projects
+
+```shell
+[
+  {
+    "id": 1,
+    "sequential_id": 1,
+    "name": "Hiring by email",
+    "slug": "hiring-by-email",
+    "description": null,
+    "summary": null,
+    "specifics": { },
+    "visibility": "not_posted",
+    "responses_due_at": null,
+    "enable_qa": false,
+    "questions_due_at": null,
+    "require_registration": false,
+    "iframe_custom_stylesheet_url": null,
+    "iframe_thanks_method": 1,
+    "iframe_thanks_custom_message": null,
+    "iframe_thanks_redirect_url": null,
+    "key_response_field_id": 1,
+    "created_at": "2014-05-07T19:19:42.273Z",
+    "updated_at": "2014-05-07T19:19:42.273Z",
+    "submitted_responses_count": 11,
+    "show_respondents": true,
+    "show_askers": true,
+    "email_responses": 3
+  },
+  ...
+]
+```
+
+### HTTP Request
+`GET /sites/:site_id/projects`
+
+## Get a single project
+
+```shell
+{
+  "id": 1,
+  "sequential_id": 1,
+  "name": "Hiring by email",
+  "slug": "hiring-by-email",
+  "description": null,
+  "summary": null,
+  "specifics": { },
+  "visibility": "not_posted",
+  "responses_due_at": null,
+  "enable_qa": false,
+  "questions_due_at": null,
+  "require_registration": false,
+  "iframe_custom_stylesheet_url": null,
+  "iframe_thanks_method": 1,
+  "iframe_thanks_custom_message": null,
+  "iframe_thanks_redirect_url": null,
+  "after_response_page": null,
+  "after_response_page_html": null,
+  "key_response_field_id": 1,
+  "created_at": "2014-05-07T19:19:42.273Z",
+  "updated_at": "2014-05-07T19:19:42.273Z",
+  "submitted_responses_count": 11,
+  "show_respondents": true,
+  "show_askers": true,
+  "email_responses": 3
+}
+```
+
+### HTTP Request
+`GET /sites/:site_id/projects/:project_id`
+
+## Create a project
+
+```shell
+curl /sites/:site_id/projects/:project_id \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  -d '
+{
+  "name": "Hiring by email",
+  "description": "<p>The description can include HTML!</p>"
+}
+'
+```
+
+### HTTP Request
+
+`POST /sites/:site_id/projects`
+
+## Update a project
+
+```shell
+curl /sites/:site_id/projects/:project_id \
+  -H 'Content-Type: application/json' \
+  -X PUT \
+  -d '
+{
+  "name": "Hiring by email",
+  "description": "<p>The description can include HTML!</p>"
+}
+'
+```
+
+### HTTP Request
+
+`PUT /sites/:site_id/projects/:project_id`
+
+## Delete a project
+
+```shell
+curl /sites/:site_id/projects/:project_id \
+  -H 'Content-Type: application/json' \
+  -X DELETE
+```
+
+### HTTP Request
+
+`DELETE /sites/:site_id/projects/:project_id`

--- a/source/index.md
+++ b/source/index.md
@@ -7,9 +7,11 @@ language_tabs:
 toc_footers:
   - <a href='https://screendoor.dobt.co'>Go to Screendoor &rarr;</a>
 
-includes: 
+includes:
   - overview
   - responses
+  - projects
+  - project-forms
 
 search: true
 ---


### PR DESCRIPTION
Closes #2.

The old docs had an example response for each example request, but in `source/includes/responses.md`, example responses are shown for only "List a project's response" and "Get a single response." 

I followed your lead: `source/includes/projects.md` and `source/includes/project-forms.md` list example responses for GET requests only.

Just curious—why'd you decide to leave them out?