### PR TITLE
Fix advanced search query param

### DIFF
--- a/source/includes/responses.md.erb
+++ b/source/includes/responses.md.erb
@@ -25,7 +25,7 @@ curl "https://screendoor.dobt.co/api/projects/2/responses?v=0&api_key=d9763djh12
 
 In addition to the parameters above, this endpoint accepts the same query parameters as Screendoor's [responses page](http://help.dobt.co/articles/screendoor/responses/viewing_a_list_of_responses.html).
 
-To find the correct parameters, consider using [advanced search](http://help.dobt.co/articles/screendoor/responses/searching_for_responses.html#using-simple-and-advanced-search) to construct a query. Then copy the `?advanced_search=` part of the resulting URL.
+To find the correct parameters, consider using [advanced search](http://help.dobt.co/articles/screendoor/responses/searching_for_responses.html#using-simple-and-advanced-search) to construct a query. Then copy the `?q=&advanced_search=` part of the resulting URL.
 
 (Since API keys aren't associated with individual users, you will not be able to use query parameters that refer to "my rating.")
 


### PR DESCRIPTION
`?advanced_search=` --> `?q=&advanced_search=` 