### PR TITLE
Change field_data type in 'update a project's form' endpoint

### DIFF
--- a/source/includes/project_forms.md.erb
+++ b/source/includes/project_forms.md.erb
@@ -43,7 +43,7 @@ curl "https://screendoor.dobt.co/api/projects/2/form?v=0&api_key=d9763djh1274" \
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| field_data | JSON-encoded Array | | Sorry, the form schema is not yet documented. |
+| field_data | JSON-encoded Hash | | Sorry, the form schema is not yet documented. |
 
 ## Add a field to the form
 


### PR DESCRIPTION
This PR corrects the documentation for the "Update a project’s form" endpoint. Previously, it said that `field_data` was a JSON-encoded array. This PR accurately depicts the `field_data` type as a JSON-encoded hash.