### PR TITLE
Add field_data wrapper and change field label in form.json

### DIFF
--- a/source/resources/form.json
+++ b/source/resources/form.json
@@ -1,8 +1,10 @@
-[
-  {
-    "id": "ak01k23k",
-    "type": "field",
-    "field_type": "paragraph",
-    "label": "Your Approach"
-  }
-]
+{
+	"field_data": [
+	  {
+	    "id": "ak01k23k",
+	    "type": "field",
+	    "field_type": "paragraph",
+	    "label": "Your Strategy"
+	  }
+	]
+}


### PR DESCRIPTION
Prompted by [this support request](https://app.frontapp.com/open/msg_168cpq1), this PR adds a `field_data` wrapper to the example response for the following endpoints:
- Show a project's form
- Update a project's form
- Add a field to the form
- Update a field in the form

This should clarify for API users that the expected response is a JSON hash rather than an array. This PR also changes the copy of the field label to match the field label in the example curl commands.

Before:
![screen shot 2018-05-07 at 4 22 36 pm](https://user-images.githubusercontent.com/970325/39729871-0660fa72-5213-11e8-820a-ca818da0081a.png)

After:
![screen shot 2018-05-07 at 4 21 56 pm](https://user-images.githubusercontent.com/970325/39729882-10301510-5213-11e8-8ca0-794faf534510.png)


@vlymar, can you do a quick sanity check for me when you have a sec? No rush.
