### PR TITLE
Upgrade json to avoid middleman errors, change header used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 # Middleman
+gem 'json', '~>1.8.5'
 gem 'middleman', '~>4.0.0'
 gem 'middleman-gh-pages', '~> 0.0.3'
 gem 'middleman-syntax', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       concurrent-ruby (~> 0.8)
     hashie (3.4.3)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.9.0)
     listen (3.0.5)
       rb-fsevent (>= 0.9.3)
@@ -122,6 +122,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json (~> 1.8.5)
   middleman (~> 4.0.0)
   middleman-autoprefixer (~> 2.7.0)
   middleman-gh-pages (~> 0.0.3)
@@ -131,4 +132,4 @@ DEPENDENCIES
   rouge (~> 1.10.1)
 
 BUNDLED WITH
-   1.10.6
+   1.17.3

--- a/source/includes/overview.md
+++ b/source/includes/overview.md
@@ -34,8 +34,8 @@ You can change the number of records that are returned by adding a `?per_page=` 
 
 The current API version is **1**.
 
-- Specify the API version by setting a `Version: 1` HTTP header
-- Alternatively, use the `?v=1` URL parameter
+- Specify the API version by using the `?v=1` URL parameter
+- Alternatively, set a `Api-Version: 1` HTTP header
 
 ## API Clients
 


### PR DESCRIPTION
# What
* Update docs to show `Api-Version` should be the HTTP header
* Upgrade JSON gem so Middleman doesn't error every time I bundle

# Why
Updates to the API.

@dobtco/serve 